### PR TITLE
Update to Support V3 Tags and Params

### DIFF
--- a/antlers.configuration.json
+++ b/antlers.configuration.json
@@ -1,6 +1,6 @@
 {
     "comments": {
-      "blockComment": [ "{{#", "#}}" ]
+        "blockComment": [ "{{#", "#}}" ]
     },
     "brackets": [
         ["{", "}"],

--- a/syntaxes/antlers.json
+++ b/syntaxes/antlers.json
@@ -10,7 +10,7 @@
   "foldingStartMarker": "{{(\\s?)",
   "foldingStopMarker": "(\\s?)}}",
   "injections": {
-    "text.html.statamic - (meta.embedded | meta.tag | comment.block.statamic), L:(text.html.statamic meta.tag - (comment.block.statamic | meta.embedded.statamic)), L:(source.js.embedded.html - (comment.statamic | meta.embedded.statamic))": {
+    "text.html.statamic - (meta.embedded | meta.tag | comment.block.statamic), L:(text.html.statamic meta.tag - (comment.block.statamic | meta.embedded.statamic))": {
       "patterns": [
         {
           "include": "#statamic-comments"
@@ -37,13 +37,7 @@
       "name": "meta.embedded.block.statamic",
       "patterns": [
         {
-          "include": "#statamic-overall-tags"
-        },
-        {
           "include": "#statamic-tag-addon-builtin"
-        },
-        {
-          "include": "#statamic-tag-parameter-known"
         },
         {
           "include": "#statamic-tag-parameter-variable"
@@ -57,7 +51,7 @@
       ]
     },
     "statamic-tag-addon-builtin": {
-      "match": "((404|\/?asset(:)?|\/?assets(:)?|\/?cache|\/?can:cp:([a-zA-Z0-9-_:]+)|\/?collection(:([a-zA-Z0-9-_:]+))?|control_panel_edit_url|count|current_date|date_groups|dump|\/?email_form|\/?entries(:)?(listing|pagination|map|previous|next|meld)?|exists|\/?foreach(:([a-zA-Z0-9-_:]+))?|get:[a-zA-Z0-9-_\/\\:]+|\/?get_content(:([a-zA-Z0-9-_:]+))?|\/?get_files(:([a-zA-Z0-9-_:]+))?|get_post:[a-zA-Z0-9-_:]+|get_value:[a-zA-Z0-9-_:]+|glide(:batch)?|\/?in:[a-zA-Z0-9-_:]+|\/?is:[a-zA-Z0-9-_:]+|\/?items|link|\/?locales(:([a-zA-Z0-9-_:]+))?|\/?location(:(map_listing|map_url))?|log(:(debug|info|warn|error|fatal))?|login|login_form|logout|logout_url|\/?loop|markdown(:indent)?|\/?member(:(forgot_password_form|listing|pagination|profile|profile_form|register_form|reset_password_form))?|mix|\/?nav(:(exists|count|breadcrumbs))?|oauth(:([a-zA-Z0-9-_:]+))?|\/?obfuscate|old:[a-zA-Z0-9-_\\-:]+|\/?pages(:(listing|next|previous|meld))?|path|post:[a-zA-Z0-9-_:]+|\/?parent:[a-zA-Z0-9-_:]+|partial:[a-zA-Z0-9-_\/\\:]+|\/?protect:(password_form)|redirect|\/?relate:[a-zA-Z0-9-_:]+|route:[a-zA-Z0-9-_:]+|\/?search:results|section(:([a-zA-Z0-9-_:]+))?|session(:([a-zA-Z0-9-_:]+))?|svg|switch|\/?taxonomy:[a-zA-Z0-9-_:]+|\/?taxonomy:listing|theme(:([a-zA-Z0-9-_:]+))?|trans(:([a-zA-Z0-9-_:]+))?|transform|\/?user(:(can|forgot_password_form|in|is|login_form|logout|logout_url|profile|register_form|reset_password_form))?|\/?users|\/?var\\b(:([a-zA-Z0-9-_:]+))?|yield(:([a-zA-Z0-9-_:]+))?)\\b)",
+      "match": "(\\b(404|\/?asset(:)?|\/?assets(:)?|\/?cache|\/?can:cp:([a-zA-Z0-9-_:]+)|\/?collection(:([a-zA-Z0-9-_:]+))?|control_panel_edit_url|count|current_date|date_groups|dump|\/?email_form|\/?entries(:)?(listing|pagination|map|previous|next|meld)?|exists|\/?foreach(:([a-zA-Z0-9-_:]+))?|get:[a-zA-Z0-9-_\/\\:]+|\/?get_content(:([a-zA-Z0-9-_:]+))?|\/?get_files(:([a-zA-Z0-9-_:]+))?|get_post:[a-zA-Z0-9-_:]+|get_value:[a-zA-Z0-9-_:]+|glide(:batch)?|\/?in:[a-zA-Z0-9-_:]+|\/?is:[a-zA-Z0-9-_:]+|\/?items|link|\/?locales(:([a-zA-Z0-9-_:]+))?|\/?location(:(map_listing|map_url))?|log(:(debug|info|warn|error|fatal))?|login|login_form|logout|logout_url|\/?loop|markdown(:indent)?|\/?member(:(forgot_password_form|listing|pagination|profile|profile_form|register_form|reset_password_form))?|mix|\/?nav(:(exists|count|breadcrumbs))?|oauth(:([a-zA-Z0-9-_:]+))?|\/?obfuscate|old:[a-zA-Z0-9-_\\-:]+|\/?pages(:(listing|next|previous|meld))?|path|post:[a-zA-Z0-9-_:]+|\/?parent:[a-zA-Z0-9-_:]+|partial:[a-zA-Z0-9-_\/\\:]+|\/?protect:(password_form)|redirect|\/?relate:[a-zA-Z0-9-_:]+|route:[a-zA-Z0-9-_:]+|\/?search:results|section(:([a-zA-Z0-9-_:]+))?|session(:([a-zA-Z0-9-_:]+))?|svg|switch|\/?taxonomy:[a-zA-Z0-9-_:]+|\/?taxonomy:listing|theme(:([a-zA-Z0-9-_:]+))?|trans(:([a-zA-Z0-9-_:]+))?|transform|\/?user(:(can|forgot_password_form|in|is|login_form|logout|logout_url|profile|register_form|reset_password_form))?|\/?users|\/?var\\b(:([a-zA-Z0-9-_:]+))?|yield(:([a-zA-Z0-9-_:]+))?)\\b)",
       "captures": {
         "1": {
           "patterns": [{
@@ -77,16 +71,20 @@
         }
       }
     },
-    "statamic-tag-parameter-known": {
-      "match": "(:?(absolute|action|add|allow_request_redirect|allow_request_return|ampersand_list|as|ascii|at|attr|backspace|bcc|between|blur|brightness|by|cache_bust|camelize|cc|cdata|ceil|center_point|class|clusters|collapse|collapse_whitespace|collection|conditions|console_log|container|contains|contains_all|contains_any|contrast|count|count_substring|crop|current|current_first|dashify|days_ago|decode|depth|deslugify|destination|divide|dl|do|dont_use|dpr|dump|email|ends_with|ensure_left|ensure_right|entities|error_redirect|exclude|explode|ext|extension|favicon|field|fields|file|file_date|file_size|filename|filter|first|fit|flatten|flip|floor|folder|folders_only|for|form|format|format_localized|formset|from|full_urls|gamma|gravatar|greyscale|group|group_by|group_by_date|groups|handle|has_lower_case|has_upper_case|height|honeypot|hours_ago|id|image|in|include_content|include_entries|include_home|index|insert|is|is_after|is_alpha|is_alphanumeric|is_before|is_between|is_empty|is_future|is_json|is_leap_year|is_lowercase|is_numberwang|is_numeric|is_past|is_today|is_uppercase|is_weekday|is_weekend|is_yesterday|join|key|last|lcfirst|length|limit|link|links|locale|locate_with|logged_in_redirect|lower|macro|mailto|map_id|markdown|match|max_depth|member|message|min_count|minutes_ago|mod|months_ago|msg_footer|msg_header|multiply|name|nl2br|not_folder|not_from|not_in|obfuscate|obfuscate_email|offset|ol|open_popup|orient|page|paginate|param|partial|permission|pixelate|plural|pos_x|pos_y|precision|provider|quality|query|query_scope|ratio|rawurlencode|read_time|recursive|redirect|redirects|regex_replace|relative|remove_left|remove_right|repeat|replace|required|reset_return|reset_url|response|return|reverse|role|roles|rotate|round|safe_truncate|sanitize|scope|seconds_ago|segment|sentence_list|sharpen|show_future|show_hidden|show_past|show_published|show_unpublished|shuffle|since|singular|slugify|smartypants|sort|sort_by|sort_dir|specifically|square|src|starts_with|strip_tags|subject|substr|subtract|sum|supplement_data|surround|swap_case|tag|taxonomy|textile|tidy|times|title|to|to_json|to_spaces|to_tabs|trim|truncate|type|ucfirst|ul|underscored|unique|until|upper|upsize|url|urldecode|urlencode|use|use_context|username|version|watermark|weeks_ago|what|widont|width|word_count|wrap|years_ago|zoom)(=)('|\")(.*?)(\\4))",
+    "statamic-tag-parameter-variable": {
+      "match": "(:?(\\S+?)(=)('|\")([^\\4]*?)(\\4))",
       "captures": {
         "1": {
           "patterns": [
             {
-              "match": ":(.*?)(=)('|\")(.*?)(\\3)",
+              "match": ":(\\S+?)(=)('|\")(.*?)(\\3)",
               "captures": {
                 "1": {
-                  "name": "support.function.attribute.statamic"
+                  "name": "entity.other.attribute-name",
+                  "patterns": [{
+                    "match": "\\b(absolute|action|add|allow_request_redirect|allow_request_return|ampersand_list|as|ascii|at|attr|backspace|bcc|between|blur|brightness|by|cache_bust|camelize|cc|cdata|ceil|center_point|class|clusters|collapse|collapse_whitespace|collection|conditions|console_log|container|contains|contains_all|contains_any|contrast|count|count_substring|crop|current|current_first|dashify|days_ago|decode|depth|deslugify|destination|divide|dl|do|dont_use|dpr|dump|email|ends_with|ensure_left|ensure_right|entities|error_redirect|exclude|explode|ext|extension|favicon|field|fields|file|file_date|file_size|filename|filter|first|fit|flatten|flip|floor|folder|folders_only|for|form|format|format_localized|formset|from|full_urls|gamma|gravatar|greyscale|group|group_by|group_by_date|groups|handle|has_lower_case|has_upper_case|height|honeypot|hours_ago|id|image|in|include_content|include_entries|include_home|index|insert|is|is_after|is_alpha|is_alphanumeric|is_before|is_between|is_empty|is_future|is_json|is_leap_year|is_lowercase|is_numberwang|is_numeric|is_past|is_today|is_uppercase|is_weekday|is_weekend|is_yesterday|join|key|last|lcfirst|length|limit|link|links|locale|locate_with|logged_in_redirect|lower|macro|mailto|map_id|markdown|match|max_depth|member|message|min_count|minutes_ago|mod|months_ago|msg_footer|msg_header|multiply|name|nl2br|not_folder|not_from|not_in|obfuscate|obfuscate_email|offset|ol|open_popup|orient|page|paginate|param|partial|permission|pixelate|plural|pos_x|pos_y|precision|provider|quality|query|query_scope|ratio|rawurlencode|read_time|recursive|redirect|redirects|regex_replace|relative|remove_left|remove_right|repeat|replace|required|reset_return|reset_url|response|return|reverse|role|roles|rotate|round|safe_truncate|sanitize|scope|seconds_ago|segment|sentence_list|sharpen|show_future|show_hidden|show_past|show_published|show_unpublished|shuffle|since|singular|slugify|smartypants|sort|sort_by|sort_dir|specifically|square|src|starts_with|strip_tags|subject|substr|subtract|sum|supplement_data|surround|swap_case|tag|taxonomy|textile|tidy|times|title|to|to_json|to_spaces|to_tabs|trim|truncate|type|ucfirst|ul|underscored|unique|until|upper|upsize|url|urldecode|urlencode|use|use_context|username|version|watermark|weeks_ago|what|widont|width|word_count|wrap|years_ago|zoom)\\b",
+                    "name": "support.function.attribute.statamic"
+                  }]
                 },
                 "2": {
                   "name": "keyword.operator.assignment.statamic"
@@ -106,7 +104,11 @@
               "match": "([^:]+?)(=)(('|\")(.*?)(\\4))",
               "captures": {
                 "1": {
-                  "name": "support.function.attribute.statamic"
+                  "name": "entity.other.attribute-name",
+                  "patterns": [{
+                    "match": "\\b(absolute|action|add|allow_request_redirect|allow_request_return|ampersand_list|as|ascii|at|attr|backspace|bcc|between|blur|brightness|by|cache_bust|camelize|cc|cdata|ceil|center_point|class|clusters|collapse|collapse_whitespace|collection|conditions|console_log|container|contains|contains_all|contains_any|contrast|count|count_substring|crop|current|current_first|dashify|days_ago|decode|depth|deslugify|destination|divide|dl|do|dont_use|dpr|dump|email|ends_with|ensure_left|ensure_right|entities|error_redirect|exclude|explode|ext|extension|favicon|field|fields|file|file_date|file_size|filename|filter|first|fit|flatten|flip|floor|folder|folders_only|for|form|format|format_localized|formset|from|full_urls|gamma|gravatar|greyscale|group|group_by|group_by_date|groups|handle|has_lower_case|has_upper_case|height|honeypot|hours_ago|id|image|in|include_content|include_entries|include_home|index|insert|is|is_after|is_alpha|is_alphanumeric|is_before|is_between|is_empty|is_future|is_json|is_leap_year|is_lowercase|is_numberwang|is_numeric|is_past|is_today|is_uppercase|is_weekday|is_weekend|is_yesterday|join|key|last|lcfirst|length|limit|link|links|locale|locate_with|logged_in_redirect|lower|macro|mailto|map_id|markdown|match|max_depth|member|message|min_count|minutes_ago|mod|months_ago|msg_footer|msg_header|multiply|name|nl2br|not_folder|not_from|not_in|obfuscate|obfuscate_email|offset|ol|open_popup|orient|page|paginate|param|partial|permission|pixelate|plural|pos_x|pos_y|precision|provider|quality|query|query_scope|ratio|rawurlencode|read_time|recursive|redirect|redirects|regex_replace|relative|remove_left|remove_right|repeat|replace|required|reset_return|reset_url|response|return|reverse|role|roles|rotate|round|safe_truncate|sanitize|scope|seconds_ago|segment|sentence_list|sharpen|show_future|show_hidden|show_past|show_published|show_unpublished|shuffle|since|singular|slugify|smartypants|sort|sort_by|sort_dir|specifically|square|src|starts_with|strip_tags|subject|substr|subtract|sum|supplement_data|surround|swap_case|tag|taxonomy|textile|tidy|times|title|to|to_json|to_spaces|to_tabs|trim|truncate|type|ucfirst|ul|underscored|unique|until|upper|upsize|url|urldecode|urlencode|use|use_context|username|version|watermark|weeks_ago|what|widont|width|word_count|wrap|years_ago|zoom)\\b",
+                    "name": "support.function.attribute.statamic"
+                  }]
                 },
                 "2": {
                   "name": "keyword.operator.assignment.statamic"
@@ -120,26 +122,6 @@
               }
             }
           ]
-        }
-      }
-    },
-    "statamic-tag-parameter-variable": {
-      "match": "\\s:(.+?)(=)('|\")([^\\3]*?)(\\3)",
-      "captures": {
-        "1": {
-          "name": "entity.other.attribute-name"
-        },
-        "2": {
-          "name": "keyword.operator.assignment.statamic"
-        },
-        "3": {
-          "name": "punctuation.definition.parameters.begin.quote.double.statamic"
-        },
-        "4": {
-          "patterns": [{"include": "#expression-valid"}]
-        },
-        "5": {
-          "name": "punctuation.definition.parameters.end.quote.double.statamic"
         }
       }
     },

--- a/syntaxes/antlers.json
+++ b/syntaxes/antlers.json
@@ -19,14 +19,24 @@
   ],
   "repository": {
     "statamic-comments": {
-      "begin": "\\{\\{\\#",
-      "end": "\\#\\}\\}",
+      "begin": "{{#",
+      "end": "#}}",
       "name": "comment.block.statamic"
     },
     "statamic-overall-tags": {
-      "begin": "\\{\\{(\\s?)",
-      "end": "(\\s?)\\}\\}",
-      "name": "punctuation.tag.statamic",
+      "begin": "{{(\\s?)",
+      "beginCaptures": {
+          "0": {
+              "name": "punctuation.definition.block.begin.statamic"
+          }
+      },
+      "end": "(\\s?)}}",
+      "endCaptures": {
+          "0": {
+              "name": "punctuation.definition.block.end.statamic"
+          }
+      },
+      "name": "punctuation.definition.block.statamic",
       "patterns": [
         {
           "include": "#statamic-overall-tags"
@@ -38,6 +48,9 @@
           "include": "#statamic-tag-parameter-known"
         },
         {
+          "include": "#statamic-tag-parameter-variable"
+        },
+        {
           "include": "#statamic-tag-conditional"
         },
         {
@@ -46,15 +59,94 @@
       ]
     },
     "statamic-tag-addon-builtin": {
-      "match": "(404|/?asset(:)?|/?assets(:)?|/?cache|/?can:cp:([a-zA-Z0-9-_:]+)|/?collection(:)?([a-zA-Z0-9-_:]+)?|control_panel_edit_url|count|current_date|date_groups|/?email_form|/?entries(:)?(listing|pagination|map|previous|next|meld)?|exists|get:[a-zA-Z0-9-_:]+|/?get_content|/?get_files|get_post:[a-zA-Z0-9-_:]+|get_value:[a-zA-Z0-9-_:]+|glide|/?in:[a-zA-Z0-9-_:]+|/?is:[a-zA-Z0-9-_:]+|/?location(:)?(map_listing|map_url)?|log(:)?(debug|info|warn|error|fatal)?|login|login_form|logout|logout_url|/?member(:)?(forgot_password_form|listing|pagination|profile|profile_form|register_form|reset_password_form)?|/?nav(:)?(exists|count|breadcrumbs)?|/?obfuscate|old:[a-zA-Z0-9-_\\-:]+|/?pages(:)?(listing|next|previous|meld)?|path|post:[a-zA-Z0-9-_:]+|/?parent:[a-zA-Z0-9-_:]+|partial:[a-zA-Z0-9-_\\-:]+|/?protect:(password_form)|redirect|/?relate:[a-zA-Z0-9-_:]+|/?search:results|switch|/?taxonomy:[a-zA-Z0-9-_:]+|/?taxonomy:listing|theme(:)?([a-zA-Z0-9-_:]+)?|transform|/?user(:)?(can|forgot_password_form|in|is|login_form|logout|logout_url|profile|register_form|reset_password_form)?|/?users|/?var\\b(:)?([a-zA-Z0-9-_:]+)?)\\b",
-      "name": "meta.function-call.statamic"
+      "match": "((404|\/?asset(:)?|\/?assets(:)?|\/?cache|\/?can:cp:([a-zA-Z0-9-_:]+)|\/?collection(:([a-zA-Z0-9-_:]+))?|control_panel_edit_url|count|current_date|date_groups|\/?email_form|\/?entries(:)?(listing|pagination|map|previous|next|meld)?|exists|get:[a-zA-Z0-9-_\/\\:]+|\/?get_content|\/?get_files|get_post:[a-zA-Z0-9-_:]+|get_value:[a-zA-Z0-9-_:]+|glide|\/?in:[a-zA-Z0-9-_:]+|\/?is:[a-zA-Z0-9-_:]+|\/?location(:(map_listing|map_url))?|log(:(debug|info|warn|error|fatal))?|login|login_form|logout|logout_url|\/?member(:(forgot_password_form|listing|pagination|profile|profile_form|register_form|reset_password_form))?|\/?nav(:(exists|count|breadcrumbs))?|\/?obfuscate|old:[a-zA-Z0-9-_\\-:]+|\/?pages(:(listing|next|previous|meld))?|path|post:[a-zA-Z0-9-_:]+|\/?parent:[a-zA-Z0-9-_:]+|partial:[a-zA-Z0-9-_\/\\:]+|\/?protect:(password_form)|redirect|\/?relate:[a-zA-Z0-9-_:]+|\/?search:results|switch|\/?taxonomy:[a-zA-Z0-9-_:]+|\/?taxonomy:listing|theme(:([a-zA-Z0-9-_:]+))?|transform|\/?user(:(can|forgot_password_form|in|is|login_form|logout|logout_url|profile|register_form|reset_password_form))?|\/?users|\/?var\\b(:([a-zA-Z0-9-_:]+))?)\\b)",
+      "captures": {
+        "1": {
+          "patterns": [{
+            "match": "(\/?[a-zA-Z0-9-_]+(:cp)?)((:)([a-zA-Z0-9-_\/\\:]+))?",
+            "captures": {
+              "1": {
+                "name": "support.class.builtin.tag.statamic"
+              },
+              "4": {
+                "name": "punctuation.definition.parameters.begin.statamic"
+              },
+              "5": {
+                "name": "variable.parameter.statamic"
+              }
+            }
+          }]
+        }
+      }
     },
     "statamic-tag-parameter-known": {
-      "match": "(action|add|allow_request_return|ampersand_list|as|ascii|at|attr|backspace|bcc|between|blur|brightness|cache_bust|camelize|cc|cdata|ceil|center_point|class|clusters|collapse|collapse_whitespace|collection|conditions|console_log|contains|contains_all|contains_any|contrast|count|count_substring|crop|current|dashify|days_ago|decode|depth|deslugify|destination|divide|dl|do|dump|email|ends_with|ensure_left|ensure_right|entities|exclude|explode|extension|favicon|field|fields|file_date|file_size|file|filename|filter|first|fit|flatten|flip|floor|folder|folders_only|for|format|format_localized|from|full_urls|gamma|gravatar|greyscale|group|groups|group_by|group_by_date|has_lower_case|has_upper_case|height|honeypot|hours_ago|id|image|in|include_content|include_entries|include_home|insert|is|is_after|is_alpha|is_alphanumeric|is_before|is_between|is_empty|is_future|is_json|is_leap_year|is_lowercase|is_numberwang|is_numeric|is_past|is_today|is_uppercase|is_weekday|is_weekend|is_yesterday|join|key|last|lcfirst|length|limit|link|locate_with|logged_in_redirect|lower|macro|mailto|map_id|markdown|match|max_depth|member|message|min_count|minutes_ago|mod|months_ago|msg_footer|msg_header|multiply|name|nl2br|not_in|obfuscate|obfuscate_email|offset|ol|open_popup|orient|page|paginate|param|partial|permission|pixelate|plural|pos_x|pos_y|precision|quality|ratio|rawurlencode|read_time|redirect|regex_replace|relative|remove_left|remove_right|repeat|replace|required|reset_return|reset_url|response|return|reverse|role|roles|rotate|round|safe_truncate|sanitize|scope|seconds_ago|sentence_list|segment|sharpen|show_future|show_hidden|show_past|show_unpublished|shuffle|singular|since|slugify|smartypants|sort_by|sort_dir|sort|specifically|square|src|starts_with|strip_tags|subject|substr|subtract|sum|surround|swap_case|tag|taxonomy|textile|tidy|title|to|to_json|to_spaces|to_tabs|trim|truncate|type|ucfirst|ul|underscored|unique|until|upper|upsize|url|urldecode|urlencode|use_context|username|version|watermark|weeks_ago|what|widont|width|word_count|wrap|years_ago|zoom)=(?!=)",
-      "name": "support.function.parameter.statamic"
+      "match": "(:?(action|add|allow_request_return|ampersand_list|as|ascii|at|attr|backspace|bcc|between|blur|brightness|cache_bust|camelize|cc|cdata|ceil|center_point|class|clusters|collapse|collapse_whitespace|collection|conditions|console_log|contains|contains_all|contains_any|contrast|count|count_substring|crop|current|dashify|days_ago|decode|depth|deslugify|destination|divide|dl|do|dump|email|ends_with|ensure_left|ensure_right|entities|exclude|explode|extension|favicon|field|fields|file_date|file_size|file|filename|filter|first|fit|flatten|flip|floor|folder|folders_only|for|format|format_localized|from|full_urls|gamma|gravatar|greyscale|group|groups|group_by|group_by_date|has_lower_case|has_upper_case|height|honeypot|hours_ago|id|image|in|include_content|include_entries|include_home|insert|is|is_after|is_alpha|is_alphanumeric|is_before|is_between|is_empty|is_future|is_json|is_leap_year|is_lowercase|is_numberwang|is_numeric|is_past|is_today|is_uppercase|is_weekday|is_weekend|is_yesterday|join|key|last|lcfirst|length|limit|link|locate_with|logged_in_redirect|lower|macro|mailto|map_id|markdown|match|max_depth|member|message|min_count|minutes_ago|mod|months_ago|msg_footer|msg_header|multiply|name|nl2br|not_in|obfuscate|obfuscate_email|offset|ol|open_popup|orient|page|paginate|param|partial|permission|pixelate|plural|pos_x|pos_y|precision|quality|ratio|rawurlencode|read_time|redirect|regex_replace|relative|remove_left|remove_right|repeat|replace|required|reset_return|reset_url|response|return|reverse|role|roles|rotate|round|safe_truncate|sanitize|scope|seconds_ago|sentence_list|segment|sharpen|show_future|show_hidden|show_past|show_unpublished|shuffle|singular|since|slugify|smartypants|sort_by|sort_dir|sort|specifically|square|src|starts_with|strip_tags|subject|substr|subtract|sum|surround|swap_case|tag|taxonomy|textile|tidy|title|to|to_json|to_spaces|to_tabs|trim|truncate|type|ucfirst|ul|underscored|unique|until|upper|upsize|url|urldecode|urlencode|use_context|username|version|watermark|weeks_ago|what|widont|width|word_count|wrap|years_ago|zoom)(=)('|\")(.*?)(\\4))",
+      "captures": {
+        "1": {
+          "patterns": [
+            {
+              "match": ":(.*?)(=)('|\")(.*?)(\\3)",
+              "captures": {
+                "1": {
+                  "name": "support.function.attribute.statamic"
+                },
+                "2": {
+                  "name": "keyword.operator.assignment.statamic"
+                },
+                "3": {
+                  "name": "punctuation.definition.parameters.begin.quote.double.statamic"
+                },
+                "4": {
+                  "patterns": [{"include": "#expression-valid"}]
+                },
+                "5": {
+                  "name": "punctuation.definition.parameters.end.quote.double.statamic"
+                }
+              }
+            },
+            {
+              "match": "([^:]+?)(=)(('|\")(.*?)(\\4))",
+              "captures": {
+                "1": {
+                  "name": "support.function.attribute.statamic"
+                },
+                "2": {
+                  "name": "keyword.operator.assignment.statamic"
+                },
+                "3": {
+                  "patterns" : [
+                    { "include": "#statamic-string-single-quoted"},
+                    { "include": "#statamic-string-double-quoted"}
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "statamic-tag-parameter-variable": {
+      "match": "\\s:(.+?)(=)('|\")([^\\3]*?)(\\3)",
+      "captures": {
+        "1": {
+          "name": "entity.other.attribute-name"
+        },
+        "2": {
+          "name": "keyword.operator.assignment.statamic"
+        },
+        "3": {
+          "name": "punctuation.definition.parameters.begin.quote.double.statamic"
+        },
+        "4": {
+          "patterns": [{"include": "#expression-valid"}]
+        },
+        "5": {
+          "name": "punctuation.definition.parameters.end.quote.double.statamic"
+        }
+      }
     },
     "statamic-tag-native-variable": {
-      "match": "(\\G|\\s|\\b)(_is_draft|_is_hidden|_site_name|_site_url|recursive\\schildren|alt|basename|/?children|collection|content|count|current_uri|current_url|date|date_group|datestamp|email_sent|environment|error|/?errors|expired|extension|field_errors:[a-zA-Z0-9-_:]+|file|filename|first|get|get_post|grouped_date|has_entries|has_next|has_previous|homepage|id|index|is_[a-zA-Z0-9-_:]+|is_admin|is_current|is_entry|is_image|is_page|is_parent|is_published|is_\\[role\\]|in_\\[group\\]|last_modified_instance|last_modified_timestamp|last_modified|last_segment|last|layout_content|locale|logged_in|name|next_page|next|no_results|now|old_values:[a-zA-Z0-9-_:]+|page_url|parent|path|permalink|post|prev|previous_page|previous|response_code|results|search_score|segment_[0-9]+|site_url|size_b|size_bytes|size_gb|size_gigabytes|size_kb|size_kilobytes|size_mb|size_megabytes|size|slug|success|taxonomy_name|taxonomy_slug|theme_path|title|total_found|total_results|url_invalid|url|username|zero_index)\\b(?![\\=\\-\\:])",
+      "match": "(\\G|\\s|\\b)(_is_draft|_is_hidden|_site_name|_site_url|recursive\\schildren|alt|basename|\/?children|collection|content|count|current_uri|current_url|date|date_group|datestamp|email_sent|environment|error|\/?errors|expired|extension|field_errors:[a-zA-Z0-9-_:]+|file|filename|first|get|get_post|grouped_date|has_entries|has_next|has_previous|homepage|id|index|is_[a-zA-Z0-9-_:]+|is_admin|is_current|is_entry|is_image|is_page|is_parent|is_published|is_\\[role\\]|in_\\[group\\]|last_modified_instance|last_modified_timestamp|last_modified|last_segment|last|layout_content|locale|logged_in|name|next_page|next|no_results|now|old_values:[a-zA-Z0-9-_:]+|page_url|paginate|parent|path|permalink|post|prev|previous_page|previous|response_code|results|search_score|segment_[0-9]+|site_url|size_b|size_bytes|size_gb|size_gigabytes|size_kb|size_kilobytes|size_mb|size_megabytes|size|slug|success|taxonomy_name|taxonomy_slug|theme_path|title|total_found|total_results|url_invalid|url|username|zero_index)\\b(?![\\=\\-\\:])",
       "captures": {
         "2": {
           "name": "variable.language.statamic"
@@ -62,7 +154,7 @@
       }
     },
     "statamic-variable": {
-      "match": "(/?\\w+)(:)?(\\w+)?",
+      "match": "(\/?\\w+)(:)?(\\w+)?",
       "captures": {
         "1": {
           "name": "variable.other.statamic"
@@ -71,7 +163,7 @@
           "name": "keyword.operator.other.statamic"
         },
         "3": {
-          "name": "support.function.statamic"
+          "name": "variable.other.property.statamic"
         }
       }
     },
@@ -87,7 +179,7 @@
       }
     },
     "statamic-tag-conditional": {
-      "match": "(/?else|/?elseif|/?if|/?unless|endif|endunless|unlesselse)",
+      "match": "(\/?else|\/?elseif|\/?if|\/?unless|endif|endunless|unlesselse)",
       "name": "keyword.control.statamic"
     },
     "statamic-tag-operator": {
@@ -112,17 +204,40 @@
     },
     "statamic-not-operator": {
       "match": "(\\s|^)(!)",
-      "name": "keyword.operator.other.statamic"
+      "captures": {
+        "2": {
+          "name": "keyword.operator.other.statamic"
+        }
+      }
     },
     "statamic-string-double-quoted": {
       "begin": "\"",
       "end": "\"",
-      "name": "string.quoted.double.html"
+      "name": "string.quoted.double.statamic"
     },
     "statamic-string-single-quoted": {
       "begin": "'",
       "end": "'",
-      "name": "string.quoted.single.html"
+      "name": "string.quoted.single.statamic"
+    },
+    "expression-valid": {
+      "patterns": [
+        {
+          "include": "#statamic-constant-numbers"
+        },
+        {
+          "include": "#statamic-constant-language"
+        },
+        {
+          "include": "#statamic-tag-native-variable"
+        },
+        {
+          "include": "#statamic-variable"
+        },
+        {
+          "include": "#statamic-var-modifiers"
+        }
+      ] 
     },
     "tag-stuff": {
       "patterns": [

--- a/syntaxes/antlers.json
+++ b/syntaxes/antlers.json
@@ -1,22 +1,30 @@
 {
   "fileTypes": [
+    "antlers.html",
     "html",
     "htm",
     "xhtml"
   ],
   "name": "Antlers (Statamic Syntax)",
-  "patterns": [
-    {
-      "include": "#statamic-comments"
-    },
-    {
-      "include": "#statamic-overall-tags"
-    },
-    {
-      "comment": "This is set to use XHTML standards, but you can change that by changing .strict to .basic for HTML standards",
-      "include": "text.html.basic"
+  "scopeName": "text.html.statamic",
+  "foldingStartMarker": "{{(\\s?)",
+  "foldingStopMarker": "(\\s?)}}",
+  "injections": {
+    "text.html.statamic - (meta.embedded | meta.tag | comment.block.statamic), L:(text.html.statamic meta.tag - (comment.block.statamic | meta.embedded.statamic)), L:(source.js.embedded.html - (comment.statamic | meta.embedded.statamic))": {
+      "patterns": [
+        {
+          "include": "#statamic-comments"
+        },
+        {
+          "include": "#statamic-overall-tags"
+        },
+        {
+          "comment": "This is set to use XHTML standards, but you can change that by changing .strict to .basic for HTML standards",
+          "include": "text.html.basic"
+        }
+      ]
     }
-  ],
+  },
   "repository": {
     "statamic-comments": {
       "begin": "{{#",
@@ -25,18 +33,8 @@
     },
     "statamic-overall-tags": {
       "begin": "{{(\\s?)",
-      "beginCaptures": {
-          "0": {
-              "name": "punctuation.definition.block.begin.statamic"
-          }
-      },
       "end": "(\\s?)}}",
-      "endCaptures": {
-          "0": {
-              "name": "punctuation.definition.block.end.statamic"
-          }
-      },
-      "name": "punctuation.definition.block.statamic",
+      "name": "meta.embedded.block.statamic",
       "patterns": [
         {
           "include": "#statamic-overall-tags"
@@ -59,7 +57,7 @@
       ]
     },
     "statamic-tag-addon-builtin": {
-      "match": "((404|\/?asset(:)?|\/?assets(:)?|\/?cache|\/?can:cp:([a-zA-Z0-9-_:]+)|\/?collection(:([a-zA-Z0-9-_:]+))?|control_panel_edit_url|count|current_date|date_groups|\/?email_form|\/?entries(:)?(listing|pagination|map|previous|next|meld)?|exists|get:[a-zA-Z0-9-_\/\\:]+|\/?get_content|\/?get_files|get_post:[a-zA-Z0-9-_:]+|get_value:[a-zA-Z0-9-_:]+|glide|\/?in:[a-zA-Z0-9-_:]+|\/?is:[a-zA-Z0-9-_:]+|\/?location(:(map_listing|map_url))?|log(:(debug|info|warn|error|fatal))?|login|login_form|logout|logout_url|\/?member(:(forgot_password_form|listing|pagination|profile|profile_form|register_form|reset_password_form))?|\/?nav(:(exists|count|breadcrumbs))?|\/?obfuscate|old:[a-zA-Z0-9-_\\-:]+|\/?pages(:(listing|next|previous|meld))?|path|post:[a-zA-Z0-9-_:]+|\/?parent:[a-zA-Z0-9-_:]+|partial:[a-zA-Z0-9-_\/\\:]+|\/?protect:(password_form)|redirect|\/?relate:[a-zA-Z0-9-_:]+|\/?search:results|switch|\/?taxonomy:[a-zA-Z0-9-_:]+|\/?taxonomy:listing|theme(:([a-zA-Z0-9-_:]+))?|transform|\/?user(:(can|forgot_password_form|in|is|login_form|logout|logout_url|profile|register_form|reset_password_form))?|\/?users|\/?var\\b(:([a-zA-Z0-9-_:]+))?)\\b)",
+      "match": "((404|\/?asset(:)?|\/?assets(:)?|\/?cache|\/?can:cp:([a-zA-Z0-9-_:]+)|\/?collection(:([a-zA-Z0-9-_:]+))?|control_panel_edit_url|count|current_date|date_groups|dump|\/?email_form|\/?entries(:)?(listing|pagination|map|previous|next|meld)?|exists|\/?foreach(:([a-zA-Z0-9-_:]+))?|get:[a-zA-Z0-9-_\/\\:]+|\/?get_content(:([a-zA-Z0-9-_:]+))?|\/?get_files(:([a-zA-Z0-9-_:]+))?|get_post:[a-zA-Z0-9-_:]+|get_value:[a-zA-Z0-9-_:]+|glide(:batch)?|\/?in:[a-zA-Z0-9-_:]+|\/?is:[a-zA-Z0-9-_:]+|\/?items|link|\/?locales(:([a-zA-Z0-9-_:]+))?|\/?location(:(map_listing|map_url))?|log(:(debug|info|warn|error|fatal))?|login|login_form|logout|logout_url|\/?loop|markdown(:indent)?|\/?member(:(forgot_password_form|listing|pagination|profile|profile_form|register_form|reset_password_form))?|mix|\/?nav(:(exists|count|breadcrumbs))?|oauth(:([a-zA-Z0-9-_:]+))?|\/?obfuscate|old:[a-zA-Z0-9-_\\-:]+|\/?pages(:(listing|next|previous|meld))?|path|post:[a-zA-Z0-9-_:]+|\/?parent:[a-zA-Z0-9-_:]+|partial:[a-zA-Z0-9-_\/\\:]+|\/?protect:(password_form)|redirect|\/?relate:[a-zA-Z0-9-_:]+|route:[a-zA-Z0-9-_:]+|\/?search:results|section(:([a-zA-Z0-9-_:]+))?|session(:([a-zA-Z0-9-_:]+))?|svg|switch|\/?taxonomy:[a-zA-Z0-9-_:]+|\/?taxonomy:listing|theme(:([a-zA-Z0-9-_:]+))?|trans(:([a-zA-Z0-9-_:]+))?|transform|\/?user(:(can|forgot_password_form|in|is|login_form|logout|logout_url|profile|register_form|reset_password_form))?|\/?users|\/?var\\b(:([a-zA-Z0-9-_:]+))?|yield(:([a-zA-Z0-9-_:]+))?)\\b)",
       "captures": {
         "1": {
           "patterns": [{
@@ -80,7 +78,7 @@
       }
     },
     "statamic-tag-parameter-known": {
-      "match": "(:?(action|add|allow_request_return|ampersand_list|as|ascii|at|attr|backspace|bcc|between|blur|brightness|cache_bust|camelize|cc|cdata|ceil|center_point|class|clusters|collapse|collapse_whitespace|collection|conditions|console_log|contains|contains_all|contains_any|contrast|count|count_substring|crop|current|dashify|days_ago|decode|depth|deslugify|destination|divide|dl|do|dump|email|ends_with|ensure_left|ensure_right|entities|exclude|explode|extension|favicon|field|fields|file_date|file_size|file|filename|filter|first|fit|flatten|flip|floor|folder|folders_only|for|format|format_localized|from|full_urls|gamma|gravatar|greyscale|group|groups|group_by|group_by_date|has_lower_case|has_upper_case|height|honeypot|hours_ago|id|image|in|include_content|include_entries|include_home|insert|is|is_after|is_alpha|is_alphanumeric|is_before|is_between|is_empty|is_future|is_json|is_leap_year|is_lowercase|is_numberwang|is_numeric|is_past|is_today|is_uppercase|is_weekday|is_weekend|is_yesterday|join|key|last|lcfirst|length|limit|link|locate_with|logged_in_redirect|lower|macro|mailto|map_id|markdown|match|max_depth|member|message|min_count|minutes_ago|mod|months_ago|msg_footer|msg_header|multiply|name|nl2br|not_in|obfuscate|obfuscate_email|offset|ol|open_popup|orient|page|paginate|param|partial|permission|pixelate|plural|pos_x|pos_y|precision|quality|ratio|rawurlencode|read_time|redirect|regex_replace|relative|remove_left|remove_right|repeat|replace|required|reset_return|reset_url|response|return|reverse|role|roles|rotate|round|safe_truncate|sanitize|scope|seconds_ago|sentence_list|segment|sharpen|show_future|show_hidden|show_past|show_unpublished|shuffle|singular|since|slugify|smartypants|sort_by|sort_dir|sort|specifically|square|src|starts_with|strip_tags|subject|substr|subtract|sum|surround|swap_case|tag|taxonomy|textile|tidy|title|to|to_json|to_spaces|to_tabs|trim|truncate|type|ucfirst|ul|underscored|unique|until|upper|upsize|url|urldecode|urlencode|use_context|username|version|watermark|weeks_ago|what|widont|width|word_count|wrap|years_ago|zoom)(=)('|\")(.*?)(\\4))",
+      "match": "(:?(absolute|action|add|allow_request_redirect|allow_request_return|ampersand_list|as|ascii|at|attr|backspace|bcc|between|blur|brightness|by|cache_bust|camelize|cc|cdata|ceil|center_point|class|clusters|collapse|collapse_whitespace|collection|conditions|console_log|container|contains|contains_all|contains_any|contrast|count|count_substring|crop|current|current_first|dashify|days_ago|decode|depth|deslugify|destination|divide|dl|do|dont_use|dpr|dump|email|ends_with|ensure_left|ensure_right|entities|error_redirect|exclude|explode|ext|extension|favicon|field|fields|file|file_date|file_size|filename|filter|first|fit|flatten|flip|floor|folder|folders_only|for|form|format|format_localized|formset|from|full_urls|gamma|gravatar|greyscale|group|group_by|group_by_date|groups|handle|has_lower_case|has_upper_case|height|honeypot|hours_ago|id|image|in|include_content|include_entries|include_home|index|insert|is|is_after|is_alpha|is_alphanumeric|is_before|is_between|is_empty|is_future|is_json|is_leap_year|is_lowercase|is_numberwang|is_numeric|is_past|is_today|is_uppercase|is_weekday|is_weekend|is_yesterday|join|key|last|lcfirst|length|limit|link|links|locale|locate_with|logged_in_redirect|lower|macro|mailto|map_id|markdown|match|max_depth|member|message|min_count|minutes_ago|mod|months_ago|msg_footer|msg_header|multiply|name|nl2br|not_folder|not_from|not_in|obfuscate|obfuscate_email|offset|ol|open_popup|orient|page|paginate|param|partial|permission|pixelate|plural|pos_x|pos_y|precision|provider|quality|query|query_scope|ratio|rawurlencode|read_time|recursive|redirect|redirects|regex_replace|relative|remove_left|remove_right|repeat|replace|required|reset_return|reset_url|response|return|reverse|role|roles|rotate|round|safe_truncate|sanitize|scope|seconds_ago|segment|sentence_list|sharpen|show_future|show_hidden|show_past|show_published|show_unpublished|shuffle|since|singular|slugify|smartypants|sort|sort_by|sort_dir|specifically|square|src|starts_with|strip_tags|subject|substr|subtract|sum|supplement_data|surround|swap_case|tag|taxonomy|textile|tidy|times|title|to|to_json|to_spaces|to_tabs|trim|truncate|type|ucfirst|ul|underscored|unique|until|upper|upsize|url|urldecode|urlencode|use|use_context|username|version|watermark|weeks_ago|what|widont|width|word_count|wrap|years_ago|zoom)(=)('|\")(.*?)(\\4))",
       "captures": {
         "1": {
           "patterns": [
@@ -144,6 +142,11 @@
           "name": "punctuation.definition.parameters.end.quote.double.statamic"
         }
       }
+    },
+    "statamic-string-interpolation-expression": {
+      "begin": "{",
+      "end": "}",
+      "patterns": [{ "include": "#expression-valid" }]
     },
     "statamic-tag-native-variable": {
       "match": "(\\G|\\s|\\b)(_is_draft|_is_hidden|_site_name|_site_url|recursive\\schildren|alt|basename|\/?children|collection|content|count|current_uri|current_url|date|date_group|datestamp|email_sent|environment|error|\/?errors|expired|extension|field_errors:[a-zA-Z0-9-_:]+|file|filename|first|get|get_post|grouped_date|has_entries|has_next|has_previous|homepage|id|index|is_[a-zA-Z0-9-_:]+|is_admin|is_current|is_entry|is_image|is_page|is_parent|is_published|is_\\[role\\]|in_\\[group\\]|last_modified_instance|last_modified_timestamp|last_modified|last_segment|last|layout_content|locale|logged_in|name|next_page|next|no_results|now|old_values:[a-zA-Z0-9-_:]+|page_url|paginate|parent|path|permalink|post|prev|previous_page|previous|response_code|results|search_score|segment_[0-9]+|site_url|size_b|size_bytes|size_gb|size_gigabytes|size_kb|size_kilobytes|size_mb|size_megabytes|size|slug|success|taxonomy_name|taxonomy_slug|theme_path|title|total_found|total_results|url_invalid|url|username|zero_index)\\b(?![\\=\\-\\:])",
@@ -213,12 +216,14 @@
     "statamic-string-double-quoted": {
       "begin": "\"",
       "end": "\"",
-      "name": "string.quoted.double.statamic"
+      "name": "string.quoted.double.statamic",
+      "patterns": [{ "include": "#statamic-string-interpolation-expression" }]
     },
     "statamic-string-single-quoted": {
       "begin": "'",
       "end": "'",
-      "name": "string.quoted.single.statamic"
+      "name": "string.quoted.single.statamic",
+      "patterns": [{ "include": "#statamic-string-interpolation-expression" }]
     },
     "expression-valid": {
       "patterns": [
@@ -270,6 +275,5 @@
         }
       ]
     }
-  },
-  "scopeName": "text.html.statamic"
+  }
 }


### PR DESCRIPTION
This PR adds a few changes:
## 1. Update tags to match V3
I've updated the Tags and Parameters to match what has been added in v3. I have not removed anything that has been deprecated.

## 2. Update syntax highlighting to work everywhere where appropriate
I also added better support for antlers tags inside of other scopes, for example, when using antlers inside of an HTML tag attribute, the syntax highlighting would go away:

**Before:**
<img width="634" alt="Screen Shot 2020-10-31 at 9 26 52 PM" src="https://user-images.githubusercontent.com/1687902/97793245-e8995b00-1bbf-11eb-9fca-bc9e7bb608a6.png">

**After:**
<img width="632" alt="Screen Shot 2020-10-31 at 9 27 21 PM" src="https://user-images.githubusercontent.com/1687902/97793251-f4851d00-1bbf-11eb-80bf-699cec4e8cbc.png">

## 3. Switch parameters that use dynamic binding to better highlight variables/values
Previously, parameters that were using [dynamic binding](https://statamic.dev/antlers?ref=docs.statamic.com#variables-inside-tag-parameters) would always show as a string. They are now dynamic.

**Before:**
<img width="221" alt="Screen Shot 2020-10-31 at 10 18 05 PM" src="https://user-images.githubusercontent.com/1687902/97793788-2188fe00-1bc7-11eb-8449-b58f7c279166.png">

**After:**
<img width="227" alt="Screen Shot 2020-10-31 at 10 17 13 PM" src="https://user-images.githubusercontent.com/1687902/97793794-2948a280-1bc7-11eb-89e9-8932140f65b6.png">


## 4. Add support for string interpolation syntax highlighting
Same as the previous point, string interpolation also didn't highlight correctly. Now it does

**Before:**
<img width="470" alt="Screen Shot 2020-10-31 at 10 17 53 PM" src="https://user-images.githubusercontent.com/1687902/97793809-5c8b3180-1bc7-11eb-9db9-97ddfa363717.png">

**After:**
<img width="473" alt="Screen Shot 2020-10-31 at 10 17 29 PM" src="https://user-images.githubusercontent.com/1687902/97793810-614fe580-1bc7-11eb-96ed-b253d7b5bd57.png">
